### PR TITLE
Fix thread join issue when closing network connection

### DIFF
--- a/mbed/src/iot_network.cpp
+++ b/mbed/src/iot_network.cpp
@@ -168,7 +168,7 @@ static IotNetworkError_t network_new(IotNetworkServerInfo_t pServerInfo,
 static IotNetworkError_t network_set_receive_callback(IotNetworkConnection_t pConnection,
                                                       IotNetworkReceiveCallback_t receiveCallback,
                                                       void * pContext) {
-    tr_info("Setting network receive callback");
+    tr_debug("Setting network receive callback");
     pConnection->mtx.lock();
     pConnection->on_recv_ctx = pContext;
     pConnection->on_recv = receiveCallback;

--- a/mbed/src/iot_network.cpp
+++ b/mbed/src/iot_network.cpp
@@ -180,7 +180,7 @@ static IotNetworkError_t network_set_close_callback(IotNetworkConnection_t pConn
                                                     IotNetworkCloseCallback_t closeCallback,
                                                     void * pContext){
     // Note: Currently the IotMqtt library does not call this function
-    tr_info("Setting network close callback");
+    tr_debug("Setting network close callback");
     pConnection->mtx.lock();
     pConnection->on_close_ctx = pContext;
     pConnection->on_close = closeCallback;


### PR DESCRIPTION
The AWS IotNetworkClose function can be called by different threads:
- the main application thread can disconnect the connection by calling `IotMqtt_Disconnect`
- any thread in the IotMqtt library can close the connection as part of error handling

This lead to an issue where an application could be hanging due to improper calls to `thread.join()` when closing the network connection.